### PR TITLE
Apply sort order even if query is empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,24 +1021,19 @@
             const sortOrder = document.getElementById('sort-order').value;
             const limit = document.getElementById('result-limit').value;
 
-            if (!query) {
-                showSearchResults(conversationsData.slice(0, 25));
-                return;
-            }
-
             let results;
-            
+
             if (searchType === 'tags') {
                 // Tag-based search
                 const tagNames = query.split(',').map(tag => tag.trim()).filter(tag => tag);
-                results = searchConversationsByTags(tagNames);
+                results = tagNames.length === 0 ? [...conversationsData] : searchConversationsByTags(tagNames);
             } else {
-                // Traditional content search
+                // Traditional content search (title, content, or both)
                 results = searchConversations(query, searchType);
             }
-            
+
             results = sortResults(results, sortOrder);
-            
+
             if (limit !== 'all') {
                 results = results.slice(0, parseInt(limit));
             }


### PR DESCRIPTION
When running a search with an empty query (no text entered), the frontend was previously skipping the sort step and just showing the first 25 conversations in unsorted order.

This fix removes the early return in performSearch() and ensures that the selected sort order (like “Oldest First” or “Newest First”) always applies—even for empty queries.

- Removed the `if (!query)` early return block that bypassed sorting.
- Now, sortResults() runs on the full dataset, regardless of search input.
- Limit still applies as before.